### PR TITLE
dualprf attributes

### DIFF
--- a/pyodim/pyodim.py
+++ b/pyodim/pyodim.py
@@ -290,7 +290,7 @@ def get_dataset_metadata(hfile, dataset: str = "dataset1") -> Tuple[Dict, Dict]:
 
     # General metadata
     ds_how = hfile[f"/{dataset}/how"]
-    for k in {"NI", "highprf", "product"} & ds_how.attrs.keys():
+    for k in {"NI", "highprf", "product", "prt", "rapic_UNFOLDING", "rapic_HIPRF"} & ds_how.attrs.keys():
         metadata[k] = ds_how.attrs[k]
 
     sdate = hfile[f"/{dataset}/what"].attrs["startdate"].decode("utf-8")


### PR DESCRIPTION
Added some extra attributes to cover the two implementations of dualprf metadata in Bureau radar volumes

From the rapic era, the following additional attributes are needed to define (1) the prf ratio and (2) which pulse has which prf (e.g, high PRF on odd pulses)
Specifically, these attributes are named:
- rapic_UNFOLDING
- rapic_HIPRF
Both return binary strings (e.g., rapic_UNFOLDING = b'2:3' rapic_HIPRF = b'ODDS')
Using these values it's possible to reconstruct the prt for each ray

For the modern area, only a single additional attribute is needed
- prt
This returns a numpy array of prt values (floats) for each ray.

These three attributes are extracted for each sweep alongside NI etc. The existing implementation works well for ignoring attributes which don't exist.

This will greatly help me improve the dual prf correction code implementation!
