### PR TITLE
Extra dualprf metadata

### DIFF
--- a/pyodim/pyodim.py
+++ b/pyodim/pyodim.py
@@ -353,7 +353,7 @@ def get_dataset_metadata(hfile, dataset: str = "dataset1") -> Tuple[Dict, Dict]:
         try:
             metadata['prt'] = prt_from_rapic_metadata(metadata, coordinates_metadata["nrays"])
         except Exception as e:
-            warnings.warn(f"Failed to build PRT array from legacy metadata due to error: {e}", UserWarning)
+            warnings.warn(f"Failed to build PRT array for {dataset} from legacy metadata due to error: {e}", UserWarning)
 
     return metadata, coordinates_metadata
 


### PR DESCRIPTION
This new feature is able to parse dual prf metadata both the modern odimh5 compliant files and legacy converted rapic file.

Possible attributes read relating to the dual prf array from the odimh5 file include: ""prt", "rapic_UNFOLDING", "rapic_HIPRF"

When rapic attributes exist, these are parsed into an array of prt value for each ray in a sweep, which is consistent with the metadata from odimh5 compliant files.

If either the "prt" metadata or "rapic_UNFOLDING", "rapic_HIPRF" metadata fields are missing, it is assumed the sweep uses a single prf.